### PR TITLE
APPS-4250: Fixed executable path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,13 @@
     },
     "autoload": {
         "psr-4": {
-            "SprykerSdk\\SyncApi\\": "src/SprykerSdk/SyncApi",
-            "Transfer\\": "src/Transfer"
+            "SprykerSdk\\SyncApi\\": "src/SprykerSdk/SyncApi/",
+            "Transfer\\": "src/Transfer/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "SprykerSdkTest\\SyncApi\\": "tests/SprykerSdkTest/SyncApi",
+            "SprykerSdkTest\\SyncApi\\": "tests/SprykerSdkTest/SyncApi/",
             "SprykerSdkTest\\Helper\\": "tests/_support/Helper/"
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "autoload": {
         "psr-4": {
             "SprykerSdk\\SyncApi\\": "src/SprykerSdk/SyncApi",
-            "Generated\\Shared\\Transfer\\": "src/Generated/Shared/Transfer/"
+            "Transfer\\": "src/Transfer"
         }
     },
     "autoload-dev": {

--- a/src/SprykerSdk/SyncApi/Console/AbstractConsole.php
+++ b/src/SprykerSdk/SyncApi/Console/AbstractConsole.php
@@ -72,7 +72,7 @@ class AbstractConsole extends Command
 
     /**
      * @param \Symfony\Component\Console\Output\OutputInterface $output
-     * @param \ArrayObject<int, \Generated\Shared\Transfer\MessageTransfer> $messageTransfers
+     * @param \ArrayObject<int, \Transfer\MessageTransfer> $messageTransfers
      *
      * @return void
      */

--- a/src/SprykerSdk/SyncApi/Console/OpenApiCodeGenerateConsole.php
+++ b/src/SprykerSdk/SyncApi/Console/OpenApiCodeGenerateConsole.php
@@ -7,10 +7,10 @@
 
 namespace SprykerSdk\SyncApi\Console;
 
-use Generated\Shared\Transfer\OpenApiRequestTransfer;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Transfer\OpenApiRequestTransfer;
 
 class OpenApiCodeGenerateConsole extends AbstractConsole
 {

--- a/src/SprykerSdk/SyncApi/Console/OpenApiCodeGenerateConsole.php
+++ b/src/SprykerSdk/SyncApi/Console/OpenApiCodeGenerateConsole.php
@@ -45,23 +45,12 @@ class OpenApiCodeGenerateConsole extends AbstractConsole
     public const OPTION_ORGANIZATION_SHORT = 'o';
 
     /**
-     * @var string
-     */
-    public const OPTION_PROJECT_ROOT = 'project-root';
-
-    /**
-     * @var string
-     */
-    public const OPTION_PROJECT_ROOT_SHORT = 'r';
-
-    /**
      * @return void
      */
     protected function configure(): void
     {
         $this->setName('code:openapi:generate')
             ->setDescription('Generates code from an OpenAPI file definition.')
-            ->addOption(static::OPTION_PROJECT_ROOT, static::OPTION_PROJECT_ROOT_SHORT, InputOption::VALUE_REQUIRED, '', getcwd())
             ->addOption(static::OPTION_OPEN_API_FILE, static::OPTION_OPEN_API_FILE_SHORT, InputOption::VALUE_REQUIRED, '', $this->getConfig()->getDefaultRelativePathToOpenApiFile())
             ->addOption(static::APPLICATION_TYPE, static::APPLICATION_TYPE_SHORT, InputOption::VALUE_REQUIRED, '', 'backend')
             ->addOption(static::OPTION_ORGANIZATION, static::OPTION_ORGANIZATION_SHORT, InputOption::VALUE_REQUIRED, 'Namespace that should be used for the code builder. When set to Spryker code will be generated in the core modules.', 'App');
@@ -78,7 +67,6 @@ class OpenApiCodeGenerateConsole extends AbstractConsole
         $openApiRequestTransfer = new OpenApiRequestTransfer();
         $openApiRequestTransfer
             ->setTargetFile($input->getOption(static::OPTION_OPEN_API_FILE))
-            ->setProjectRoot($input->getOption(static::OPTION_PROJECT_ROOT))
             ->setApplicationType($input->getOption(static::APPLICATION_TYPE))
             ->setOrganization($input->getOption(static::OPTION_ORGANIZATION));
 

--- a/src/SprykerSdk/SyncApi/Console/OpenApiCreateConsole.php
+++ b/src/SprykerSdk/SyncApi/Console/OpenApiCreateConsole.php
@@ -7,12 +7,12 @@
 
 namespace SprykerSdk\SyncApi\Console;
 
-use Generated\Shared\Transfer\OpenApiRequestTransfer;
-use Generated\Shared\Transfer\OpenApiTransfer;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Transfer\OpenApiRequestTransfer;
+use Transfer\OpenApiTransfer;
 
 class OpenApiCreateConsole extends AbstractConsole
 {

--- a/src/SprykerSdk/SyncApi/Console/OpenApiValidateConsole.php
+++ b/src/SprykerSdk/SyncApi/Console/OpenApiValidateConsole.php
@@ -7,10 +7,10 @@
 
 namespace SprykerSdk\SyncApi\Console;
 
-use Generated\Shared\Transfer\ValidateRequestTransfer;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Transfer\ValidateRequestTransfer;
 
 class OpenApiValidateConsole extends AbstractConsole
 {

--- a/src/SprykerSdk/SyncApi/Message/MessageBuilder.php
+++ b/src/SprykerSdk/SyncApi/Message/MessageBuilder.php
@@ -7,14 +7,14 @@
 
 namespace SprykerSdk\SyncApi\Message;
 
-use Generated\Shared\Transfer\MessageTransfer;
+use Transfer\MessageTransfer;
 
 class MessageBuilder implements MessageBuilderInterface
 {
     /**
      * @param string $message
      *
-     * @return \Generated\Shared\Transfer\MessageTransfer
+     * @return \Transfer\MessageTransfer
      */
     public function buildMessage(string $message): MessageTransfer
     {

--- a/src/SprykerSdk/SyncApi/Message/MessageBuilderInterface.php
+++ b/src/SprykerSdk/SyncApi/Message/MessageBuilderInterface.php
@@ -7,14 +7,14 @@
 
 namespace SprykerSdk\SyncApi\Message;
 
-use Generated\Shared\Transfer\MessageTransfer;
+use Transfer\MessageTransfer;
 
 interface MessageBuilderInterface
 {
     /**
      * @param string $message
      *
-     * @return \Generated\Shared\Transfer\MessageTransfer
+     * @return \Transfer\MessageTransfer
      */
     public function buildMessage(string $message): MessageTransfer;
 }

--- a/src/SprykerSdk/SyncApi/OpenApi/Builder/OpenApiBuilder.php
+++ b/src/SprykerSdk/SyncApi/OpenApi/Builder/OpenApiBuilder.php
@@ -7,12 +7,12 @@
 
 namespace SprykerSdk\SyncApi\OpenApi\Builder;
 
-use Generated\Shared\Transfer\OpenApiRequestTransfer;
-use Generated\Shared\Transfer\OpenApiResponseTransfer;
 use SprykerSdk\SyncApi\Message\MessageBuilderInterface;
 use SprykerSdk\SyncApi\Message\SyncApiError;
 use SprykerSdk\SyncApi\Message\SyncApiInfo;
 use Symfony\Component\Yaml\Yaml;
+use Transfer\OpenApiRequestTransfer;
+use Transfer\OpenApiResponseTransfer;
 
 class OpenApiBuilder implements OpenApiBuilderInterface
 {
@@ -30,9 +30,9 @@ class OpenApiBuilder implements OpenApiBuilderInterface
     }
 
     /**
-     * @param \Generated\Shared\Transfer\OpenApiRequestTransfer $openApiRequestTransfer
+     * @param \Transfer\OpenApiRequestTransfer $openApiRequestTransfer
      *
-     * @return \Generated\Shared\Transfer\OpenApiResponseTransfer
+     * @return \Transfer\OpenApiResponseTransfer
      */
     public function createOpenApi(OpenApiRequestTransfer $openApiRequestTransfer): OpenApiResponseTransfer
     {

--- a/src/SprykerSdk/SyncApi/OpenApi/Builder/OpenApiBuilderInterface.php
+++ b/src/SprykerSdk/SyncApi/OpenApi/Builder/OpenApiBuilderInterface.php
@@ -7,15 +7,15 @@
 
 namespace SprykerSdk\SyncApi\OpenApi\Builder;
 
-use Generated\Shared\Transfer\OpenApiRequestTransfer;
-use Generated\Shared\Transfer\OpenApiResponseTransfer;
+use Transfer\OpenApiRequestTransfer;
+use Transfer\OpenApiResponseTransfer;
 
 interface OpenApiBuilderInterface
 {
     /**
-     * @param \Generated\Shared\Transfer\OpenApiRequestTransfer $openApiRequestTransfer
+     * @param \Transfer\OpenApiRequestTransfer $openApiRequestTransfer
      *
-     * @return \Generated\Shared\Transfer\OpenApiResponseTransfer
+     * @return \Transfer\OpenApiResponseTransfer
      */
     public function createOpenApi(OpenApiRequestTransfer $openApiRequestTransfer): OpenApiResponseTransfer;
 }

--- a/src/SprykerSdk/SyncApi/OpenApi/Builder/OpenApiCodeBuilder.php
+++ b/src/SprykerSdk/SyncApi/OpenApi/Builder/OpenApiCodeBuilder.php
@@ -284,7 +284,7 @@ class OpenApiCodeBuilder implements OpenApiCodeBuilderInterface
         array $commands
     ): array {
         $commands[] = [
-            'spryk-run',
+            $this->config->getSprykRunExecutablePath() . '/vendor/bin/spryk-run',
             'AddGlueResourceMethodResponse',
             '--mode', $this->sprykMode,
             '--organization', $organization,
@@ -769,7 +769,7 @@ class OpenApiCodeBuilder implements OpenApiCodeBuilderInterface
         ?string $singular
     ): array {
         $commandData = [
-            'spryk-run',
+            $this->config->getSprykRunExecutablePath() . '/vendo/bin/spryk-run',
             'AddSharedTransferProperty',
             '--mode', $this->sprykMode,
             '--organization', $organization,
@@ -815,7 +815,7 @@ class OpenApiCodeBuilder implements OpenApiCodeBuilderInterface
      */
     protected function runProcess(array $command): void
     {
-        $process = new Process($command, $this->config->getSprykRunExecutablePath(), null, null, 300);
+        $process = new Process($command, $this->config->getProjectRootPath(), null, null, 300);
 
         $process->run(function ($a, $buffer) {
             echo $buffer;

--- a/src/SprykerSdk/SyncApi/OpenApi/Builder/OpenApiCodeBuilder.php
+++ b/src/SprykerSdk/SyncApi/OpenApi/Builder/OpenApiCodeBuilder.php
@@ -769,7 +769,7 @@ class OpenApiCodeBuilder implements OpenApiCodeBuilderInterface
         ?string $singular
     ): array {
         $commandData = [
-            $this->config->getSprykRunExecutablePath() . '/vendo/bin/spryk-run',
+            $this->config->getSprykRunExecutablePath() . '/vendor/bin/spryk-run',
             'AddSharedTransferProperty',
             '--mode', $this->sprykMode,
             '--organization', $organization,

--- a/src/SprykerSdk/SyncApi/OpenApi/Builder/OpenApiCodeBuilder.php
+++ b/src/SprykerSdk/SyncApi/OpenApi/Builder/OpenApiCodeBuilder.php
@@ -14,18 +14,18 @@ use cebe\openapi\spec\PathItem;
 use cebe\openapi\spec\Reference;
 use cebe\openapi\spec\Schema;
 use Doctrine\Inflector\Inflector;
-use Generated\Shared\Transfer\OpenApiRequestTransfer;
-use Generated\Shared\Transfer\OpenApiResponseTransfer;
 use SprykerSdk\SyncApi\Message\MessageBuilderInterface;
 use SprykerSdk\SyncApi\Message\SyncApiError;
 use SprykerSdk\SyncApi\Message\SyncApiInfo;
 use SprykerSdk\SyncApi\SyncApiConfig;
 use Symfony\Component\Process\Process;
+use Transfer\OpenApiRequestTransfer;
+use Transfer\OpenApiResponseTransfer;
 
 class OpenApiCodeBuilder implements OpenApiCodeBuilderInterface
 {
     /**
-     * @var \Generated\Shared\Transfer\OpenApiResponseTransfer
+     * @var \Transfer\OpenApiResponseTransfer
      */
     protected OpenApiResponseTransfer $openApiResponseTransfer;
 
@@ -63,9 +63,9 @@ class OpenApiCodeBuilder implements OpenApiCodeBuilderInterface
     }
 
     /**
-     * @param \Generated\Shared\Transfer\OpenApiRequestTransfer $openApiRequestTransfer
+     * @param \Transfer\OpenApiRequestTransfer $openApiRequestTransfer
      *
-     * @return \Generated\Shared\Transfer\OpenApiResponseTransfer
+     * @return \Transfer\OpenApiResponseTransfer
      */
     public function build(OpenApiRequestTransfer $openApiRequestTransfer): OpenApiResponseTransfer
     {
@@ -98,7 +98,7 @@ class OpenApiCodeBuilder implements OpenApiCodeBuilderInterface
     }
 
     /**
-     * @param \Generated\Shared\Transfer\OpenApiRequestTransfer $openApiRequestTransfer
+     * @param \Transfer\OpenApiRequestTransfer $openApiRequestTransfer
      *
      * @return void
      */
@@ -110,7 +110,7 @@ class OpenApiCodeBuilder implements OpenApiCodeBuilderInterface
     }
 
     /**
-     * @param \Generated\Shared\Transfer\OpenApiRequestTransfer $openApiRequestTransfer
+     * @param \Transfer\OpenApiRequestTransfer $openApiRequestTransfer
      * @param \cebe\openapi\spec\OpenApi $openApi
      *
      * @return void
@@ -128,7 +128,7 @@ class OpenApiCodeBuilder implements OpenApiCodeBuilderInterface
     }
 
     /**
-     * @param \Generated\Shared\Transfer\OpenApiRequestTransfer $openApiRequestTransfer
+     * @param \Transfer\OpenApiRequestTransfer $openApiRequestTransfer
      * @param \cebe\openapi\spec\OpenApi $openApi
      *
      * @return void

--- a/src/SprykerSdk/SyncApi/OpenApi/Builder/OpenApiCodeBuilderInterface.php
+++ b/src/SprykerSdk/SyncApi/OpenApi/Builder/OpenApiCodeBuilderInterface.php
@@ -7,15 +7,15 @@
 
 namespace SprykerSdk\SyncApi\OpenApi\Builder;
 
-use Generated\Shared\Transfer\OpenApiRequestTransfer;
-use Generated\Shared\Transfer\OpenApiResponseTransfer;
+use Transfer\OpenApiRequestTransfer;
+use Transfer\OpenApiResponseTransfer;
 
 interface OpenApiCodeBuilderInterface
 {
     /**
-     * @param \Generated\Shared\Transfer\OpenApiRequestTransfer $openApiRequestTransfer
+     * @param \Transfer\OpenApiRequestTransfer $openApiRequestTransfer
      *
-     * @return \Generated\Shared\Transfer\OpenApiResponseTransfer
+     * @return \Transfer\OpenApiResponseTransfer
      */
     public function build(OpenApiRequestTransfer $openApiRequestTransfer): OpenApiResponseTransfer;
 }

--- a/src/SprykerSdk/SyncApi/OpenApi/Validator/OpenApiValidator.php
+++ b/src/SprykerSdk/SyncApi/OpenApi/Validator/OpenApiValidator.php
@@ -8,20 +8,20 @@
 namespace SprykerSdk\SyncApi\OpenApi\Validator;
 
 use Exception;
-use Generated\Shared\Transfer\ValidateRequestTransfer;
-use Generated\Shared\Transfer\ValidateResponseTransfer;
 use SprykerSdk\SyncApi\Message\SyncApiError;
 use SprykerSdk\SyncApi\Message\SyncApiInfo;
 use SprykerSdk\SyncApi\Validator\AbstractValidator;
 use Symfony\Component\Yaml\Yaml;
+use Transfer\ValidateRequestTransfer;
+use Transfer\ValidateResponseTransfer;
 
 class OpenApiValidator extends AbstractValidator
 {
     /**
-     * @param \Generated\Shared\Transfer\ValidateRequestTransfer $validateRequestTransfer
-     * @param \Generated\Shared\Transfer\ValidateResponseTransfer|null $validateResponseTransfer
+     * @param \Transfer\ValidateRequestTransfer $validateRequestTransfer
+     * @param \Transfer\ValidateResponseTransfer|null $validateResponseTransfer
      *
-     * @return \Generated\Shared\Transfer\ValidateResponseTransfer
+     * @return \Transfer\ValidateResponseTransfer
      */
     public function validate(
         ValidateRequestTransfer $validateRequestTransfer,

--- a/src/SprykerSdk/SyncApi/OpenApi/Validator/Rules/OpenApiComponentsValidatorRule.php
+++ b/src/SprykerSdk/SyncApi/OpenApi/Validator/Rules/OpenApiComponentsValidatorRule.php
@@ -7,10 +7,10 @@
 
 namespace SprykerSdk\SyncApi\OpenApi\Validator\Rules;
 
-use Generated\Shared\Transfer\ValidateResponseTransfer;
 use SprykerSdk\SyncApi\Message\MessageBuilderInterface;
 use SprykerSdk\SyncApi\Message\SyncApiError;
 use SprykerSdk\SyncApi\Validator\Rule\ValidatorRuleInterface;
+use Transfer\ValidateResponseTransfer;
 
 class OpenApiComponentsValidatorRule implements ValidatorRuleInterface
 {
@@ -32,10 +32,10 @@ class OpenApiComponentsValidatorRule implements ValidatorRuleInterface
      *
      * @param array $openApi
      * @param string $openApiFileName
-     * @param \Generated\Shared\Transfer\ValidateResponseTransfer $validateResponseTransfer
+     * @param \Transfer\ValidateResponseTransfer $validateResponseTransfer
      * @param array|null $context
      *
-     * @return \Generated\Shared\Transfer\ValidateResponseTransfer
+     * @return \Transfer\ValidateResponseTransfer
      */
     public function validate(
         array $openApi,
@@ -48,9 +48,9 @@ class OpenApiComponentsValidatorRule implements ValidatorRuleInterface
 
     /**
      * @param array $openApi
-     * @param \Generated\Shared\Transfer\ValidateResponseTransfer $validateResponseTransfer
+     * @param \Transfer\ValidateResponseTransfer $validateResponseTransfer
      *
-     * @return \Generated\Shared\Transfer\ValidateResponseTransfer
+     * @return \Transfer\ValidateResponseTransfer
      */
     protected function validateAtLeastOneComponentExists(array $openApi, ValidateResponseTransfer $validateResponseTransfer): ValidateResponseTransfer
     {

--- a/src/SprykerSdk/SyncApi/OpenApi/Validator/Rules/OpenApiHttpMethodInPathValidatorRule.php
+++ b/src/SprykerSdk/SyncApi/OpenApi/Validator/Rules/OpenApiHttpMethodInPathValidatorRule.php
@@ -7,10 +7,10 @@
 
 namespace SprykerSdk\SyncApi\OpenApi\Validator\Rules;
 
-use Generated\Shared\Transfer\ValidateResponseTransfer;
 use SprykerSdk\SyncApi\Message\MessageBuilderInterface;
 use SprykerSdk\SyncApi\Message\SyncApiError;
 use SprykerSdk\SyncApi\Validator\Rule\ValidatorRuleInterface;
+use Transfer\ValidateResponseTransfer;
 
 class OpenApiHttpMethodInPathValidatorRule implements ValidatorRuleInterface
 {
@@ -42,10 +42,10 @@ class OpenApiHttpMethodInPathValidatorRule implements ValidatorRuleInterface
      *
      * @param array $openApi
      * @param string $openApiFileName
-     * @param \Generated\Shared\Transfer\ValidateResponseTransfer $validateResponseTransfer
+     * @param \Transfer\ValidateResponseTransfer $validateResponseTransfer
      * @param array|null $context
      *
-     * @return \Generated\Shared\Transfer\ValidateResponseTransfer
+     * @return \Transfer\ValidateResponseTransfer
      */
     public function validate(
         array $openApi,
@@ -58,9 +58,9 @@ class OpenApiHttpMethodInPathValidatorRule implements ValidatorRuleInterface
 
     /**
      * @param array $openApi
-     * @param \Generated\Shared\Transfer\ValidateResponseTransfer $validateResponseTransfer
+     * @param \Transfer\ValidateResponseTransfer $validateResponseTransfer
      *
-     * @return \Generated\Shared\Transfer\ValidateResponseTransfer
+     * @return \Transfer\ValidateResponseTransfer
      */
     protected function validateEachPathHasAtLeastOneHttpMethod(array $openApi, ValidateResponseTransfer $validateResponseTransfer): ValidateResponseTransfer
     {

--- a/src/SprykerSdk/SyncApi/OpenApi/Validator/Rules/OpenApiPathValidatorRule.php
+++ b/src/SprykerSdk/SyncApi/OpenApi/Validator/Rules/OpenApiPathValidatorRule.php
@@ -7,10 +7,10 @@
 
 namespace SprykerSdk\SyncApi\OpenApi\Validator\Rules;
 
-use Generated\Shared\Transfer\ValidateResponseTransfer;
 use SprykerSdk\SyncApi\Message\MessageBuilderInterface;
 use SprykerSdk\SyncApi\Message\SyncApiError;
 use SprykerSdk\SyncApi\Validator\Rule\ValidatorRuleInterface;
+use Transfer\ValidateResponseTransfer;
 
 class OpenApiPathValidatorRule implements ValidatorRuleInterface
 {
@@ -32,10 +32,10 @@ class OpenApiPathValidatorRule implements ValidatorRuleInterface
      *
      * @param array $openApi
      * @param string $openApiFileName
-     * @param \Generated\Shared\Transfer\ValidateResponseTransfer $validateResponseTransfer
+     * @param \Transfer\ValidateResponseTransfer $validateResponseTransfer
      * @param array|null $context
      *
-     * @return \Generated\Shared\Transfer\ValidateResponseTransfer
+     * @return \Transfer\ValidateResponseTransfer
      */
     public function validate(
         array $openApi,
@@ -48,9 +48,9 @@ class OpenApiPathValidatorRule implements ValidatorRuleInterface
 
     /**
      * @param array $openApi
-     * @param \Generated\Shared\Transfer\ValidateResponseTransfer $validateResponseTransfer
+     * @param \Transfer\ValidateResponseTransfer $validateResponseTransfer
      *
-     * @return \Generated\Shared\Transfer\ValidateResponseTransfer
+     * @return \Transfer\ValidateResponseTransfer
      */
     protected function validateAtLeastOnePathExists(array $openApi, ValidateResponseTransfer $validateResponseTransfer): ValidateResponseTransfer
     {

--- a/src/SprykerSdk/SyncApi/SyncApiConfig.php
+++ b/src/SprykerSdk/SyncApi/SyncApiConfig.php
@@ -27,6 +27,16 @@ class SyncApiConfig
     }
 
     /**
+     * @api
+     *
+     * @return string
+     */
+    public function getProjectRootPath(): string
+    {
+        return (string)getcwd();
+    }
+
+    /**
      * Returns the current working directory or `INSTALLED_ROOT_DIRECTORY` (when INSTALLED_ROOT_DIRECTORY is defined).
      * This is needed to be able to execute this tool within the SprykerSdk and not inside of a project directly.
      *

--- a/src/SprykerSdk/SyncApi/SyncApiConfig.php
+++ b/src/SprykerSdk/SyncApi/SyncApiConfig.php
@@ -25,4 +25,35 @@ class SyncApiConfig
 
         return implode(DIRECTORY_SEPARATOR, $pathFragments);
     }
+
+    /**
+     * Returns `vendor/bin/` (default) or `INSTALLED_ROOT_DIRECTORY/vendor/bin/` (when INSTALLED_ROOT_DIRECTORY is defined).
+     *
+     * @return string
+     */
+    public function getSprykRunExecutablePath(): string
+    {
+        $pathFragments = [
+            $this->getInstalledRootDirectory(),
+            'vendor',
+            'bin',
+        ];
+
+        return implode(DIRECTORY_SEPARATOR, $pathFragments) . DIRECTORY_SEPARATOR;
+    }
+
+    /**
+     * Returns the current working directory or `INSTALLED_ROOT_DIRECTORY` (when INSTALLED_ROOT_DIRECTORY is defined).
+     * This is needed to be able to execute this tool within the SprykerSdk and not inside of a project directly.
+     *
+     * @return string
+     */
+    protected function getInstalledRootDirectory(): string
+    {
+        if (getenv('INSTALLED_ROOT_DIRECTORY')) {
+            return getenv('INSTALLED_ROOT_DIRECTORY');
+        }
+
+        return (string)getcwd();
+    }
 }

--- a/src/SprykerSdk/SyncApi/SyncApiConfig.php
+++ b/src/SprykerSdk/SyncApi/SyncApiConfig.php
@@ -27,28 +27,12 @@ class SyncApiConfig
     }
 
     /**
-     * Returns `vendor/bin/` (default) or `INSTALLED_ROOT_DIRECTORY/vendor/bin/` (when INSTALLED_ROOT_DIRECTORY is defined).
-     *
-     * @return string
-     */
-    public function getSprykRunExecutablePath(): string
-    {
-        $pathFragments = [
-            $this->getInstalledRootDirectory(),
-            'vendor',
-            'bin',
-        ];
-
-        return implode(DIRECTORY_SEPARATOR, $pathFragments) . DIRECTORY_SEPARATOR;
-    }
-
-    /**
      * Returns the current working directory or `INSTALLED_ROOT_DIRECTORY` (when INSTALLED_ROOT_DIRECTORY is defined).
      * This is needed to be able to execute this tool within the SprykerSdk and not inside of a project directly.
      *
      * @return string
      */
-    protected function getInstalledRootDirectory(): string
+    public function getSprykRunExecutablePath(): string
     {
         if (getenv('INSTALLED_ROOT_DIRECTORY')) {
             return getenv('INSTALLED_ROOT_DIRECTORY');

--- a/src/SprykerSdk/SyncApi/SyncApiFacade.php
+++ b/src/SprykerSdk/SyncApi/SyncApiFacade.php
@@ -7,10 +7,10 @@
 
 namespace SprykerSdk\SyncApi;
 
-use Generated\Shared\Transfer\OpenApiRequestTransfer;
-use Generated\Shared\Transfer\OpenApiResponseTransfer;
-use Generated\Shared\Transfer\ValidateRequestTransfer;
-use Generated\Shared\Transfer\ValidateResponseTransfer;
+use Transfer\OpenApiRequestTransfer;
+use Transfer\OpenApiResponseTransfer;
+use Transfer\ValidateRequestTransfer;
+use Transfer\ValidateResponseTransfer;
 
 class SyncApiFacade implements SyncApiFacadeInterface
 {
@@ -46,9 +46,9 @@ class SyncApiFacade implements SyncApiFacadeInterface
      *
      * @api
      *
-     * @param \Generated\Shared\Transfer\OpenApiRequestTransfer $openApiRequestTransfer
+     * @param \Transfer\OpenApiRequestTransfer $openApiRequestTransfer
      *
-     * @return \Generated\Shared\Transfer\OpenApiResponseTransfer
+     * @return \Transfer\OpenApiResponseTransfer
      */
     public function buildFromOpenApi(OpenApiRequestTransfer $openApiRequestTransfer): OpenApiResponseTransfer
     {
@@ -60,9 +60,9 @@ class SyncApiFacade implements SyncApiFacadeInterface
      *
      * @api
      *
-     * @param \Generated\Shared\Transfer\ValidateRequestTransfer $validateRequestTransfer
+     * @param \Transfer\ValidateRequestTransfer $validateRequestTransfer
      *
-     * @return \Generated\Shared\Transfer\ValidateResponseTransfer
+     * @return \Transfer\ValidateResponseTransfer
      */
     public function validateOpenApi(ValidateRequestTransfer $validateRequestTransfer): ValidateResponseTransfer
     {
@@ -74,9 +74,9 @@ class SyncApiFacade implements SyncApiFacadeInterface
      *
      * @api
      *
-     * @param \Generated\Shared\Transfer\OpenApiRequestTransfer $openApiRequestTransfer
+     * @param \Transfer\OpenApiRequestTransfer $openApiRequestTransfer
      *
-     * @return \Generated\Shared\Transfer\OpenApiResponseTransfer
+     * @return \Transfer\OpenApiResponseTransfer
      */
     public function createOpenApi(OpenApiRequestTransfer $openApiRequestTransfer): OpenApiResponseTransfer
     {

--- a/src/SprykerSdk/SyncApi/SyncApiFacadeInterface.php
+++ b/src/SprykerSdk/SyncApi/SyncApiFacadeInterface.php
@@ -7,23 +7,23 @@
 
 namespace SprykerSdk\SyncApi;
 
-use Generated\Shared\Transfer\OpenApiRequestTransfer;
-use Generated\Shared\Transfer\OpenApiResponseTransfer;
-use Generated\Shared\Transfer\ValidateRequestTransfer;
-use Generated\Shared\Transfer\ValidateResponseTransfer;
+use Transfer\OpenApiRequestTransfer;
+use Transfer\OpenApiResponseTransfer;
+use Transfer\ValidateRequestTransfer;
+use Transfer\ValidateResponseTransfer;
 
 interface SyncApiFacadeInterface
 {
- /**
-  * Specification:
-  * - Reads an OpenAPI file and builds code that is required.
-  *
-  * @api
-  *
-  * @param \Generated\Shared\Transfer\OpenApiRequestTransfer $openApiRequestTransfer
-  *
-  * @return \Generated\Shared\Transfer\OpenApiResponseTransfer
-  */
+    /**
+     * Specification:
+     * - Reads an OpenAPI file and builds code that is required.
+     *
+     * @api
+     *
+     * @param \Transfer\OpenApiRequestTransfer $openApiRequestTransfer
+     *
+     * @return \Transfer\OpenApiResponseTransfer
+     */
     public function buildFromOpenApi(OpenApiRequestTransfer $openApiRequestTransfer): OpenApiResponseTransfer;
 
     /**
@@ -32,9 +32,9 @@ interface SyncApiFacadeInterface
      *
      * @api
      *
-     * @param \Generated\Shared\Transfer\ValidateRequestTransfer $openApiRequestTransfer
+     * @param \Transfer\ValidateRequestTransfer $openApiRequestTransfer
      *
-     * @return \Generated\Shared\Transfer\ValidateResponseTransfer
+     * @return \Transfer\ValidateResponseTransfer
      */
     public function validateOpenApi(ValidateRequestTransfer $openApiRequestTransfer): ValidateResponseTransfer;
 
@@ -44,9 +44,9 @@ interface SyncApiFacadeInterface
      *
      * @api
      *
-     * @param \Generated\Shared\Transfer\OpenApiRequestTransfer $openApiRequestTransfer
+     * @param \Transfer\OpenApiRequestTransfer $openApiRequestTransfer
      *
-     * @return \Generated\Shared\Transfer\OpenApiResponseTransfer
+     * @return \Transfer\OpenApiResponseTransfer
      */
     public function createOpenApi(OpenApiRequestTransfer $openApiRequestTransfer): OpenApiResponseTransfer;
 }

--- a/src/SprykerSdk/SyncApi/SyncApiFactory.php
+++ b/src/SprykerSdk/SyncApi/SyncApiFactory.php
@@ -57,7 +57,7 @@ class SyncApiFactory
      */
     public function createOpenApiCodeBuilder(): OpenApiCodeBuilderInterface
     {
-        return new OpenApiCodeBuilder($this->createMessageBuilder(), $this->getInflector());
+        return new OpenApiCodeBuilder($this->getConfig(), $this->createMessageBuilder(), $this->getInflector());
     }
 
     /**

--- a/src/SprykerSdk/SyncApi/Validator/AbstractValidator.php
+++ b/src/SprykerSdk/SyncApi/Validator/AbstractValidator.php
@@ -7,9 +7,9 @@
 
 namespace SprykerSdk\SyncApi\Validator;
 
-use Generated\Shared\Transfer\ValidateResponseTransfer;
 use SprykerSdk\SyncApi\Message\MessageBuilderInterface;
 use SprykerSdk\SyncApi\SyncApiConfig;
+use Transfer\ValidateResponseTransfer;
 
 abstract class AbstractValidator implements ValidatorInterface
 {
@@ -43,10 +43,10 @@ abstract class AbstractValidator implements ValidatorInterface
     /**
      * @param array $fileData
      * @param string $fileName
-     * @param \Generated\Shared\Transfer\ValidateResponseTransfer $validateResponseTransfer
+     * @param \Transfer\ValidateResponseTransfer $validateResponseTransfer
      * @param array|null $context
      *
-     * @return \Generated\Shared\Transfer\ValidateResponseTransfer
+     * @return \Transfer\ValidateResponseTransfer
      */
     protected function executeValidatorRules(
         array $fileData,

--- a/src/SprykerSdk/SyncApi/Validator/Rule/ValidatorRuleInterface.php
+++ b/src/SprykerSdk/SyncApi/Validator/Rule/ValidatorRuleInterface.php
@@ -7,17 +7,17 @@
 
 namespace SprykerSdk\SyncApi\Validator\Rule;
 
-use Generated\Shared\Transfer\ValidateResponseTransfer;
+use Transfer\ValidateResponseTransfer;
 
 interface ValidatorRuleInterface
 {
     /**
      * @param array $data
      * @param string $fileName
-     * @param \Generated\Shared\Transfer\ValidateResponseTransfer $validateResponseTransfer
+     * @param \Transfer\ValidateResponseTransfer $validateResponseTransfer
      * @param array|null $context
      *
-     * @return \Generated\Shared\Transfer\ValidateResponseTransfer
+     * @return \Transfer\ValidateResponseTransfer
      */
     public function validate(
         array $data,

--- a/src/SprykerSdk/SyncApi/Validator/ValidatorInterface.php
+++ b/src/SprykerSdk/SyncApi/Validator/ValidatorInterface.php
@@ -7,16 +7,16 @@
 
 namespace SprykerSdk\SyncApi\Validator;
 
-use Generated\Shared\Transfer\ValidateRequestTransfer;
-use Generated\Shared\Transfer\ValidateResponseTransfer;
+use Transfer\ValidateRequestTransfer;
+use Transfer\ValidateResponseTransfer;
 
 interface ValidatorInterface
 {
     /**
-     * @param \Generated\Shared\Transfer\ValidateRequestTransfer $validateRequestTransfer
-     * @param \Generated\Shared\Transfer\ValidateResponseTransfer|null $validateResponseTransfer
+     * @param \Transfer\ValidateRequestTransfer $validateRequestTransfer
+     * @param \Transfer\ValidateResponseTransfer|null $validateResponseTransfer
      *
-     * @return \Generated\Shared\Transfer\ValidateResponseTransfer
+     * @return \Transfer\ValidateResponseTransfer
      */
     public function validate(
         ValidateRequestTransfer $validateRequestTransfer,

--- a/src/Transfer/AbstractTransfer.php
+++ b/src/Transfer/AbstractTransfer.php
@@ -5,7 +5,7 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
-namespace Generated\Shared\Transfer;
+namespace Transfer;
 
 use ArrayAccess;
 use ArrayObject;
@@ -228,7 +228,7 @@ abstract class AbstractTransfer implements TransferInterface, Serializable, Arra
      * @param \ArrayObject<int|string, mixed>|array $arrayObject
      * @param bool $ignoreMissingProperty
      *
-     * @return \ArrayObject<int, \Generated\Shared\Transfer\TransferInterface>
+     * @return \ArrayObject<int, \Transfer\TransferInterface>
      */
     protected function processArrayObject($elementType, $arrayObject, $ignoreMissingProperty = false): ArrayObject
     {
@@ -241,7 +241,7 @@ abstract class AbstractTransfer implements TransferInterface, Serializable, Arra
             }
 
             if ($arrayElement) {
-                /** @var \Generated\Shared\Transfer\TransferInterface $transferObject */
+                /** @var \Transfer\TransferInterface $transferObject */
                 $transferObject = new $elementType();
                 $transferObject->fromArray($arrayElement, $ignoreMissingProperty);
                 $result->offsetSet($key, $transferObject);
@@ -294,13 +294,13 @@ abstract class AbstractTransfer implements TransferInterface, Serializable, Arra
      * @param mixed $value
      * @param bool $ignoreMissingProperty
      *
-     * @return \Generated\Shared\Transfer\TransferInterface
+     * @return \Transfer\TransferInterface
      */
     protected function initializeNestedTransferObject($property, $value, $ignoreMissingProperty = false)
     {
         $type = $this->transferMetadata[$property]['type'];
 
-        /** @var \Generated\Shared\Transfer\TransferInterface $transferObject */
+        /** @var \Transfer\TransferInterface $transferObject */
         $transferObject = new $type();
 
         if (is_array($value)) {

--- a/src/Transfer/MessageTransfer.php
+++ b/src/Transfer/MessageTransfer.php
@@ -4,7 +4,7 @@
  * (c) Spryker Systems GmbH copyright protected
  */
 
-namespace Generated\Shared\Transfer;
+namespace Transfer;
 
 /**
  * !!! THIS FILE IS AUTO-GENERATED, EVERY CHANGE WILL BE LOST WITH THE NEXT RUN OF TRANSFER GENERATOR

--- a/src/Transfer/MessageTransfer.php
+++ b/src/Transfer/MessageTransfer.php
@@ -102,7 +102,7 @@ class MessageTransfer extends AbstractTransfer
      *
      * @param string|null $message
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\NullValueException
+     * @throws \Exception
      *
      * @return $this
      */
@@ -118,7 +118,7 @@ class MessageTransfer extends AbstractTransfer
     /**
      * @module SyncApi
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\NullValueException
+     * @throws \Exception
      *
      * @return string
      */
@@ -134,7 +134,7 @@ class MessageTransfer extends AbstractTransfer
     /**
      * @module SyncApi
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\RequiredTransferPropertyException
+     * @throws \Exception
      *
      * @return $this
      */
@@ -175,7 +175,7 @@ class MessageTransfer extends AbstractTransfer
      *
      * @param string|null $type
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\NullValueException
+     * @throws \Exception
      *
      * @return $this
      */
@@ -191,7 +191,7 @@ class MessageTransfer extends AbstractTransfer
     /**
      * @module SyncApi
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\NullValueException
+     * @throws \Exception
      *
      * @return string
      */
@@ -207,7 +207,7 @@ class MessageTransfer extends AbstractTransfer
     /**
      * @module SyncApi
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\RequiredTransferPropertyException
+     * @throws \Exception
      *
      * @return $this
      */

--- a/src/Transfer/OpenApiRequestTransfer.php
+++ b/src/Transfer/OpenApiRequestTransfer.php
@@ -5,7 +5,7 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
-namespace Generated\Shared\Transfer;
+namespace Transfer;
 
 use InvalidArgumentException;
 
@@ -46,7 +46,7 @@ class OpenApiRequestTransfer extends AbstractTransfer
     protected $targetFile;
 
     /**
-     * @var \Generated\Shared\Transfer\OpenApiTransfer|null
+     * @var \Transfer\OpenApiTransfer|null
      */
     protected $openApi;
 
@@ -221,7 +221,7 @@ class OpenApiRequestTransfer extends AbstractTransfer
     /**
      * @module SyncApi
      *
-     * @param \Generated\Shared\Transfer\OpenApiTransfer|null $openApi
+     * @param \Transfer\OpenApiTransfer|null $openApi
      *
      * @return $this
      */
@@ -236,7 +236,7 @@ class OpenApiRequestTransfer extends AbstractTransfer
     /**
      * @module SyncApi
      *
-     * @return \Generated\Shared\Transfer\OpenApiTransfer|null
+     * @return \Transfer\OpenApiTransfer|null
      */
     public function getOpenApi()
     {
@@ -246,7 +246,7 @@ class OpenApiRequestTransfer extends AbstractTransfer
     /**
      * @module SyncApi
      *
-     * @param \Generated\Shared\Transfer\OpenApiTransfer $openApi
+     * @param \Transfer\OpenApiTransfer $openApi
      *
      * @return $this
      */
@@ -258,7 +258,7 @@ class OpenApiRequestTransfer extends AbstractTransfer
     /**
      * @module SyncApi
      *
-     * @return \Generated\Shared\Transfer\OpenApiTransfer
+     * @return \Transfer\OpenApiTransfer
      */
     public function getOpenApiOrFail()
     {

--- a/src/Transfer/OpenApiRequestTransfer.php
+++ b/src/Transfer/OpenApiRequestTransfer.php
@@ -102,7 +102,7 @@ class OpenApiRequestTransfer extends AbstractTransfer
             'is_strict' => false,
         ],
         self::OPEN_API => [
-            'type' => 'Generated\Shared\Transfer\OpenApiTransfer',
+            'type' => 'Transfer\OpenApiTransfer',
             'type_shim' => null,
             'name_underscore' => 'open_api',
             'is_collection' => false,
@@ -507,7 +507,7 @@ class OpenApiRequestTransfer extends AbstractTransfer
                 case 'openApi':
                     if (is_array($value)) {
                         $type = $this->transferMetadata[$normalizedPropertyName]['type'];
-                        /** @var \Spryker\Shared\Kernel\Transfer\TransferInterface $value */
+                        /** @var \Transfer\TransferInterface $value */
                         $value = (new $type())->fromArray($value, $ignoreMissingProperty);
                     }
 

--- a/src/Transfer/OpenApiResponseTransfer.php
+++ b/src/Transfer/OpenApiResponseTransfer.php
@@ -49,7 +49,7 @@ class OpenApiResponseTransfer extends AbstractTransfer
      */
     protected $transferMetadata = [
         self::ERRORS => [
-            'type' => 'Generated\Shared\Transfer\MessageTransfer',
+            'type' => 'Transfer\MessageTransfer',
             'type_shim' => null,
             'name_underscore' => 'errors',
             'is_collection' => true,
@@ -61,7 +61,7 @@ class OpenApiResponseTransfer extends AbstractTransfer
             'is_strict' => false,
         ],
         self::MESSAGES => [
-            'type' => 'Generated\Shared\Transfer\MessageTransfer',
+            'type' => 'Transfer\MessageTransfer',
             'type_shim' => null,
             'name_underscore' => 'messages',
             'is_collection' => true,
@@ -117,7 +117,7 @@ class OpenApiResponseTransfer extends AbstractTransfer
     /**
      * @module SyncApi
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\RequiredTransferPropertyException
+     * @throws \Exception
      *
      * @return $this
      */
@@ -171,7 +171,7 @@ class OpenApiResponseTransfer extends AbstractTransfer
     /**
      * @module SyncApi
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\RequiredTransferPropertyException
+     * @throws \Exception
      *
      * @return $this
      */

--- a/src/Transfer/OpenApiResponseTransfer.php
+++ b/src/Transfer/OpenApiResponseTransfer.php
@@ -4,7 +4,7 @@
  * (c) Spryker Systems GmbH copyright protected
  */
 
-namespace Generated\Shared\Transfer;
+namespace Transfer;
 
 use ArrayObject;
 
@@ -12,7 +12,7 @@ use ArrayObject;
  * !!! THIS FILE IS AUTO-GENERATED, EVERY CHANGE WILL BE LOST WITH THE NEXT RUN OF TRANSFER GENERATOR
  * !!! DO NOT CHANGE ANYTHING IN THIS FILE
  */
-class ValidateResponseTransfer extends AbstractTransfer
+class OpenApiResponseTransfer extends AbstractTransfer
 {
     /**
      * @var string
@@ -25,12 +25,12 @@ class ValidateResponseTransfer extends AbstractTransfer
     public const MESSAGES = 'messages';
 
     /**
-     * @var \ArrayObject|\Generated\Shared\Transfer\MessageTransfer[]
+     * @var \ArrayObject|\Transfer\MessageTransfer[]
      */
     protected $errors;
 
     /**
-     * @var \ArrayObject|\Generated\Shared\Transfer\MessageTransfer[]
+     * @var \ArrayObject|\Transfer\MessageTransfer[]
      */
     protected $messages;
 
@@ -75,9 +75,9 @@ class ValidateResponseTransfer extends AbstractTransfer
     ];
 
     /**
-     * @module AopSdk
+     * @module SyncApi
      *
-     * @param \ArrayObject|\Generated\Shared\Transfer\MessageTransfer[] $errors
+     * @param \ArrayObject|\Transfer\MessageTransfer[] $errors
      *
      * @return $this
      */
@@ -90,9 +90,9 @@ class ValidateResponseTransfer extends AbstractTransfer
     }
 
     /**
-     * @module AopSdk
+     * @module SyncApi
      *
-     * @return \ArrayObject|\Generated\Shared\Transfer\MessageTransfer[]
+     * @return \ArrayObject|\Transfer\MessageTransfer[]
      */
     public function getErrors()
     {
@@ -100,9 +100,9 @@ class ValidateResponseTransfer extends AbstractTransfer
     }
 
     /**
-     * @module AopSdk
+     * @module SyncApi
      *
-     * @param \Generated\Shared\Transfer\MessageTransfer $error
+     * @param \Transfer\MessageTransfer $error
      *
      * @return $this
      */
@@ -115,7 +115,7 @@ class ValidateResponseTransfer extends AbstractTransfer
     }
 
     /**
-     * @module AopSdk
+     * @module SyncApi
      *
      * @throws \Spryker\Shared\Kernel\Transfer\Exception\RequiredTransferPropertyException
      *
@@ -129,9 +129,9 @@ class ValidateResponseTransfer extends AbstractTransfer
     }
 
     /**
-     * @module AopSdk
+     * @module SyncApi
      *
-     * @param \ArrayObject|\Generated\Shared\Transfer\MessageTransfer[] $messages
+     * @param \ArrayObject|\Transfer\MessageTransfer[] $messages
      *
      * @return $this
      */
@@ -144,9 +144,9 @@ class ValidateResponseTransfer extends AbstractTransfer
     }
 
     /**
-     * @module AopSdk
+     * @module SyncApi
      *
-     * @return \ArrayObject|\Generated\Shared\Transfer\MessageTransfer[]
+     * @return \ArrayObject|\Transfer\MessageTransfer[]
      */
     public function getMessages()
     {
@@ -154,9 +154,9 @@ class ValidateResponseTransfer extends AbstractTransfer
     }
 
     /**
-     * @module AopSdk
+     * @module SyncApi
      *
-     * @param \Generated\Shared\Transfer\MessageTransfer $message
+     * @param \Transfer\MessageTransfer $message
      *
      * @return $this
      */
@@ -169,7 +169,7 @@ class ValidateResponseTransfer extends AbstractTransfer
     }
 
     /**
-     * @module AopSdk
+     * @module SyncApi
      *
      * @throws \Spryker\Shared\Kernel\Transfer\Exception\RequiredTransferPropertyException
      *

--- a/src/Transfer/OpenApiTransfer.php
+++ b/src/Transfer/OpenApiTransfer.php
@@ -4,7 +4,7 @@
  * (c) Spryker Systems GmbH copyright protected
  */
 
-namespace Generated\Shared\Transfer;
+namespace Transfer;
 
 /**
  * !!! THIS FILE IS AUTO-GENERATED, EVERY CHANGE WILL BE LOST WITH THE NEXT RUN OF TRANSFER GENERATOR

--- a/src/Transfer/OpenApiTransfer.php
+++ b/src/Transfer/OpenApiTransfer.php
@@ -102,7 +102,7 @@ class OpenApiTransfer extends AbstractTransfer
      *
      * @param string|null $title
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\NullValueException
+     * @throws \Exception
      *
      * @return $this
      */
@@ -118,7 +118,7 @@ class OpenApiTransfer extends AbstractTransfer
     /**
      * @module SyncApi
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\NullValueException
+     * @throws \Exception
      *
      * @return string
      */
@@ -134,7 +134,7 @@ class OpenApiTransfer extends AbstractTransfer
     /**
      * @module SyncApi
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\RequiredTransferPropertyException
+     * @throws \Exception
      *
      * @return $this
      */
@@ -175,7 +175,7 @@ class OpenApiTransfer extends AbstractTransfer
      *
      * @param string|null $version
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\NullValueException
+     * @throws \Exception
      *
      * @return $this
      */
@@ -191,7 +191,7 @@ class OpenApiTransfer extends AbstractTransfer
     /**
      * @module SyncApi
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\NullValueException
+     * @throws \Exception
      *
      * @return string
      */
@@ -207,7 +207,7 @@ class OpenApiTransfer extends AbstractTransfer
     /**
      * @module SyncApi
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\RequiredTransferPropertyException
+     * @throws \Exception
      *
      * @return $this
      */

--- a/src/Transfer/TransferInterface.php
+++ b/src/Transfer/TransferInterface.php
@@ -5,7 +5,7 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
-namespace Generated\Shared\Transfer;
+namespace Transfer;
 
 interface TransferInterface
 {

--- a/src/Transfer/ValidateRequestTransfer.php
+++ b/src/Transfer/ValidateRequestTransfer.php
@@ -4,7 +4,7 @@
  * (c) Spryker Systems GmbH copyright protected
  */
 
-namespace Generated\Shared\Transfer;
+namespace Transfer;
 
 /**
  * !!! THIS FILE IS AUTO-GENERATED, EVERY CHANGE WILL BE LOST WITH THE NEXT RUN OF TRANSFER GENERATOR

--- a/src/Transfer/ValidateRequestTransfer.php
+++ b/src/Transfer/ValidateRequestTransfer.php
@@ -179,7 +179,7 @@ class ValidateRequestTransfer extends AbstractTransfer
      *
      * @param string|null $manifestPath
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\NullValueException
+     * @throws \Exception
      *
      * @return $this
      */
@@ -195,7 +195,7 @@ class ValidateRequestTransfer extends AbstractTransfer
     /**
      * @module SyncApi
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\NullValueException
+     * @throws \Exception
      *
      * @return string
      */
@@ -211,7 +211,7 @@ class ValidateRequestTransfer extends AbstractTransfer
     /**
      * @module SyncApi
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\RequiredTransferPropertyException
+     * @throws \Exception
      *
      * @return $this
      */
@@ -252,7 +252,7 @@ class ValidateRequestTransfer extends AbstractTransfer
      *
      * @param string|null $configurationFile
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\NullValueException
+     * @throws \Exception
      *
      * @return $this
      */
@@ -268,7 +268,7 @@ class ValidateRequestTransfer extends AbstractTransfer
     /**
      * @module SyncApi
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\NullValueException
+     * @throws \Exception
      *
      * @return string
      */
@@ -284,7 +284,7 @@ class ValidateRequestTransfer extends AbstractTransfer
     /**
      * @module SyncApi
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\RequiredTransferPropertyException
+     * @throws \Exception
      *
      * @return $this
      */
@@ -325,7 +325,7 @@ class ValidateRequestTransfer extends AbstractTransfer
      *
      * @param string|null $translationFile
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\NullValueException
+     * @throws \Exception
      *
      * @return $this
      */
@@ -341,7 +341,7 @@ class ValidateRequestTransfer extends AbstractTransfer
     /**
      * @module SyncApi
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\NullValueException
+     * @throws \Exception
      *
      * @return string
      */
@@ -357,7 +357,7 @@ class ValidateRequestTransfer extends AbstractTransfer
     /**
      * @module SyncApi
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\RequiredTransferPropertyException
+     * @throws \Exception
      *
      * @return $this
      */
@@ -398,7 +398,7 @@ class ValidateRequestTransfer extends AbstractTransfer
      *
      * @param string|null $asyncApiFile
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\NullValueException
+     * @throws \Exception
      *
      * @return $this
      */
@@ -414,7 +414,7 @@ class ValidateRequestTransfer extends AbstractTransfer
     /**
      * @module SyncApi
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\NullValueException
+     * @throws \Exception
      *
      * @return string
      */
@@ -430,7 +430,7 @@ class ValidateRequestTransfer extends AbstractTransfer
     /**
      * @module SyncApi
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\RequiredTransferPropertyException
+     * @throws \Exception
      *
      * @return $this
      */
@@ -471,7 +471,7 @@ class ValidateRequestTransfer extends AbstractTransfer
      *
      * @param string|null $openApiFile
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\NullValueException
+     * @throws \Exception
      *
      * @return $this
      */
@@ -487,7 +487,7 @@ class ValidateRequestTransfer extends AbstractTransfer
     /**
      * @module SyncApi
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\NullValueException
+     * @throws \Exception
      *
      * @return string
      */
@@ -503,7 +503,7 @@ class ValidateRequestTransfer extends AbstractTransfer
     /**
      * @module SyncApi
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\RequiredTransferPropertyException
+     * @throws \Exception
      *
      * @return $this
      */

--- a/src/Transfer/ValidateResponseTransfer.php
+++ b/src/Transfer/ValidateResponseTransfer.php
@@ -49,7 +49,7 @@ class ValidateResponseTransfer extends AbstractTransfer
      */
     protected $transferMetadata = [
         self::ERRORS => [
-            'type' => 'Generated\Shared\Transfer\MessageTransfer',
+            'type' => 'Transfer\MessageTransfer',
             'type_shim' => null,
             'name_underscore' => 'errors',
             'is_collection' => true,
@@ -61,7 +61,7 @@ class ValidateResponseTransfer extends AbstractTransfer
             'is_strict' => false,
         ],
         self::MESSAGES => [
-            'type' => 'Generated\Shared\Transfer\MessageTransfer',
+            'type' => 'Transfer\MessageTransfer',
             'type_shim' => null,
             'name_underscore' => 'messages',
             'is_collection' => true,
@@ -117,7 +117,7 @@ class ValidateResponseTransfer extends AbstractTransfer
     /**
      * @module AopSdk
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\RequiredTransferPropertyException
+     * @throws \Exception
      *
      * @return $this
      */
@@ -171,7 +171,7 @@ class ValidateResponseTransfer extends AbstractTransfer
     /**
      * @module AopSdk
      *
-     * @throws \Spryker\Shared\Kernel\Transfer\Exception\RequiredTransferPropertyException
+     * @throws \Exception
      *
      * @return $this
      */

--- a/src/Transfer/ValidateResponseTransfer.php
+++ b/src/Transfer/ValidateResponseTransfer.php
@@ -4,7 +4,7 @@
  * (c) Spryker Systems GmbH copyright protected
  */
 
-namespace Generated\Shared\Transfer;
+namespace Transfer;
 
 use ArrayObject;
 
@@ -12,7 +12,7 @@ use ArrayObject;
  * !!! THIS FILE IS AUTO-GENERATED, EVERY CHANGE WILL BE LOST WITH THE NEXT RUN OF TRANSFER GENERATOR
  * !!! DO NOT CHANGE ANYTHING IN THIS FILE
  */
-class OpenApiResponseTransfer extends AbstractTransfer
+class ValidateResponseTransfer extends AbstractTransfer
 {
     /**
      * @var string
@@ -25,12 +25,12 @@ class OpenApiResponseTransfer extends AbstractTransfer
     public const MESSAGES = 'messages';
 
     /**
-     * @var \ArrayObject|\Generated\Shared\Transfer\MessageTransfer[]
+     * @var \ArrayObject|\Transfer\MessageTransfer[]
      */
     protected $errors;
 
     /**
-     * @var \ArrayObject|\Generated\Shared\Transfer\MessageTransfer[]
+     * @var \ArrayObject|\Transfer\MessageTransfer[]
      */
     protected $messages;
 
@@ -75,9 +75,9 @@ class OpenApiResponseTransfer extends AbstractTransfer
     ];
 
     /**
-     * @module SyncApi
+     * @module AopSdk
      *
-     * @param \ArrayObject|\Generated\Shared\Transfer\MessageTransfer[] $errors
+     * @param \ArrayObject|\Transfer\MessageTransfer[] $errors
      *
      * @return $this
      */
@@ -90,9 +90,9 @@ class OpenApiResponseTransfer extends AbstractTransfer
     }
 
     /**
-     * @module SyncApi
+     * @module AopSdk
      *
-     * @return \ArrayObject|\Generated\Shared\Transfer\MessageTransfer[]
+     * @return \ArrayObject|\Transfer\MessageTransfer[]
      */
     public function getErrors()
     {
@@ -100,9 +100,9 @@ class OpenApiResponseTransfer extends AbstractTransfer
     }
 
     /**
-     * @module SyncApi
+     * @module AopSdk
      *
-     * @param \Generated\Shared\Transfer\MessageTransfer $error
+     * @param \Transfer\MessageTransfer $error
      *
      * @return $this
      */
@@ -115,7 +115,7 @@ class OpenApiResponseTransfer extends AbstractTransfer
     }
 
     /**
-     * @module SyncApi
+     * @module AopSdk
      *
      * @throws \Spryker\Shared\Kernel\Transfer\Exception\RequiredTransferPropertyException
      *
@@ -129,9 +129,9 @@ class OpenApiResponseTransfer extends AbstractTransfer
     }
 
     /**
-     * @module SyncApi
+     * @module AopSdk
      *
-     * @param \ArrayObject|\Generated\Shared\Transfer\MessageTransfer[] $messages
+     * @param \ArrayObject|\Transfer\MessageTransfer[] $messages
      *
      * @return $this
      */
@@ -144,9 +144,9 @@ class OpenApiResponseTransfer extends AbstractTransfer
     }
 
     /**
-     * @module SyncApi
+     * @module AopSdk
      *
-     * @return \ArrayObject|\Generated\Shared\Transfer\MessageTransfer[]
+     * @return \ArrayObject|\Transfer\MessageTransfer[]
      */
     public function getMessages()
     {
@@ -154,9 +154,9 @@ class OpenApiResponseTransfer extends AbstractTransfer
     }
 
     /**
-     * @module SyncApi
+     * @module AopSdk
      *
-     * @param \Generated\Shared\Transfer\MessageTransfer $message
+     * @param \Transfer\MessageTransfer $message
      *
      * @return $this
      */
@@ -169,7 +169,7 @@ class OpenApiResponseTransfer extends AbstractTransfer
     }
 
     /**
-     * @module SyncApi
+     * @module AopSdk
      *
      * @throws \Spryker\Shared\Kernel\Transfer\Exception\RequiredTransferPropertyException
      *

--- a/tests/SprykerSdkTest/SyncApi/SyncApiConfigTest.php
+++ b/tests/SprykerSdkTest/SyncApi/SyncApiConfigTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Copyright © 2019-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerSdkTest\SyncApi;
+
+use Codeception\Test\Unit;
+use SprykerSdk\SyncApi\SyncApiConfig;
+
+/**
+ * @group SprykerSdkTest
+ * @group SyncApi
+ * @group SyncApiConfigTest
+ */
+class SyncApiConfigTest extends Unit
+{
+    /**
+     * @var \SprykerSdkTest\SyncApi\SyncApiTester
+     */
+    protected SyncApiTester $tester;
+
+    /**
+     * Tests that ensures we get the default executable path when installed the "normal" way.
+     *
+     * @return void
+     */
+    public function testGetSprykRunExecutableReturnsDefaultExecutable(): void
+    {
+        // Arrange
+        $expectedExecutable = getcwd() . '/vendor/bin/';
+        $config = new SyncApiConfig();
+
+        // Act
+        $sprykRunExecutable = $config->getSprykRunExecutablePath();
+
+        // Assert
+        $this->assertSame($expectedExecutable, $sprykRunExecutable);
+    }
+
+    /**
+     * Tests that ensures we get a path to where this SDK is installed. Usually only when used within the SprykerSDK.
+     *
+     * @return void
+     */
+    public function testGetSprykRunExecutableReturnsExternalDefinedExecutable(): void
+    {
+        putenv('INSTALLED_ROOT_DIRECTORY=foo-bar');
+        // Arrange
+        $expectedExecutable = 'foo-bar/vendor/bin/';
+        $config = new SyncApiConfig();
+
+        // Act
+        $sprykRunExecutable = $config->getSprykRunExecutablePath();
+
+        // Assert
+        $this->assertSame($expectedExecutable, $sprykRunExecutable);
+        putenv('INSTALLED_ROOT_DIRECTORY');
+    }
+}

--- a/tests/SprykerSdkTest/SyncApi/SyncApiConfigTest.php
+++ b/tests/SprykerSdkTest/SyncApi/SyncApiConfigTest.php
@@ -30,7 +30,7 @@ class SyncApiConfigTest extends Unit
     public function testGetSprykRunExecutableReturnsDefaultExecutable(): void
     {
         // Arrange
-        $expectedExecutable = getcwd() . '/vendor/bin/';
+        $expectedExecutable = getcwd();
         $config = new SyncApiConfig();
 
         // Act
@@ -49,7 +49,7 @@ class SyncApiConfigTest extends Unit
     {
         putenv('INSTALLED_ROOT_DIRECTORY=foo-bar');
         // Arrange
-        $expectedExecutable = 'foo-bar/vendor/bin/';
+        $expectedExecutable = 'foo-bar';
         $config = new SyncApiConfig();
 
         // Act

--- a/tests/SprykerSdkTest/SyncApi/SyncApiConfigTest.php
+++ b/tests/SprykerSdkTest/SyncApi/SyncApiConfigTest.php
@@ -41,6 +41,24 @@ class SyncApiConfigTest extends Unit
     }
 
     /**
+     * Tests that ensures we get the default executable path when installed the "normal" way.
+     *
+     * @return void
+     */
+    public function testGetProjectRootPathReturnsCurrentWorkingDirectory(): void
+    {
+        // Arrange
+        $expectedExecutable = getcwd();
+        $config = new SyncApiConfig();
+
+        // Act
+        $projectRootPath = $config->getProjectRootPath();
+
+        // Assert
+        $this->assertSame($expectedExecutable, $projectRootPath);
+    }
+
+    /**
      * Tests that ensures we get a path to where this SDK is installed. Usually only when used within the SprykerSDK.
      *
      * @return void

--- a/tests/_support/Helper/OpenApiHelper.php
+++ b/tests/_support/Helper/OpenApiHelper.php
@@ -16,6 +16,7 @@ use Generated\Shared\Transfer\OpenApiTransfer;
 use SprykerSdk\SyncApi\Console\OpenApiCodeGenerateConsole;
 use SprykerSdk\SyncApi\Message\MessageBuilder;
 use SprykerSdk\SyncApi\OpenApi\Builder\OpenApiCodeBuilder;
+use SprykerSdk\SyncApi\SyncApiConfig;
 use SprykerSdk\SyncApi\SyncApiFacade;
 use SprykerSdk\SyncApi\SyncApiFactory;
 
@@ -77,6 +78,7 @@ class OpenApiHelper extends Module
         $openApiCodeBuilderStub = Stub::construct(
             OpenApiCodeBuilder::class,
             [
+                new SyncApiConfig(),
                 new MessageBuilder(),
                 InflectorFactory::create()->build(),
             ],

--- a/tests/_support/Helper/OpenApiHelper.php
+++ b/tests/_support/Helper/OpenApiHelper.php
@@ -11,21 +11,21 @@ use Codeception\Module;
 use Codeception\Stub;
 use Codeception\Stub\Expected;
 use Doctrine\Inflector\InflectorFactory;
-use Generated\Shared\Transfer\OpenApiRequestTransfer;
-use Generated\Shared\Transfer\OpenApiTransfer;
 use SprykerSdk\SyncApi\Console\OpenApiCodeGenerateConsole;
 use SprykerSdk\SyncApi\Message\MessageBuilder;
 use SprykerSdk\SyncApi\OpenApi\Builder\OpenApiCodeBuilder;
 use SprykerSdk\SyncApi\SyncApiConfig;
 use SprykerSdk\SyncApi\SyncApiFacade;
 use SprykerSdk\SyncApi\SyncApiFactory;
+use Transfer\OpenApiRequestTransfer;
+use Transfer\OpenApiTransfer;
 
 class OpenApiHelper extends Module
 {
     use SyncApiHelperTrait;
 
     /**
-     * @return \Generated\Shared\Transfer\OpenApiRequestTransfer
+     * @return \Transfer\OpenApiRequestTransfer
      */
     public function haveOpenApiAddRequest(): OpenApiRequestTransfer
     {

--- a/tests/_support/Helper/ValidatorHelper.php
+++ b/tests/_support/Helper/ValidatorHelper.php
@@ -8,8 +8,8 @@
 namespace SprykerSdkTest\Helper;
 
 use Codeception\Module;
-use Generated\Shared\Transfer\ValidateRequestTransfer;
-use Generated\Shared\Transfer\ValidateResponseTransfer;
+use Transfer\ValidateRequestTransfer;
+use Transfer\ValidateResponseTransfer;
 
 class ValidatorHelper extends Module
 {
@@ -42,7 +42,7 @@ class ValidatorHelper extends Module
     }
 
     /**
-     * @return \Generated\Shared\Transfer\ValidateRequestTransfer
+     * @return \Transfer\ValidateRequestTransfer
      */
     public function haveValidateRequest(): ValidateRequestTransfer
     {
@@ -55,7 +55,7 @@ class ValidatorHelper extends Module
     }
 
     /**
-     * @param \Generated\Shared\Transfer\ValidateResponseTransfer $validateResponseTransfer
+     * @param \Transfer\ValidateResponseTransfer $validateResponseTransfer
      *
      * @return array
      */


### PR DESCRIPTION
- Developer(s): @vol4onok

- Ticket: https://spryker.atlassian.net/browse/APPS-4251

- Release Group: https://release.spryker.com/release-groups/view/4151

_- PR Overview: https://release.spryker.com/release/pull-request-sdk/SyncApi/2_

- merge: squash

Module SyncApi

##### Change log

Improvements

- Introduced `SyncApiConfig::getProjectRootPath()`.
- Introduced `SyncApiConfig::getSprykRunExecutablePath()`.
- Adjusted `OpenApiCodeBuilder` so it uses new path for spryk command from config instead of project path.
- Removed `OpenApiCodeGenerateConsole::OPTION_PROJECT_ROOT` and `OpenApiCodeGenerateConsole::OPTION_PROJECT_ROOT_SHORT`
- Adjusted namespace for transfers.