### PR TITLE
APPS-4625 Skip generation for response schemas without data structures (e.g. text/plain responses)

### DIFF
--- a/src/SprykerSdk/SyncApi/OpenApi/Builder/OpenApiCodeBuilder.php
+++ b/src/SprykerSdk/SyncApi/OpenApi/Builder/OpenApiCodeBuilder.php
@@ -564,7 +564,11 @@ class OpenApiCodeBuilder implements OpenApiCodeBuilderInterface
     {
         foreach ($contents as $response) {
             if (isset($response->schema)) {
-                $responses[$this->getTransferNameFromSchemaOrReference($response->schema)] = $this->getResponsePropertiesFromSchemaOrReference($response->schema, []);
+                $responseProperties = $this->getResponsePropertiesFromSchemaOrReference($response->schema, []);
+                if (!empty($responseProperties)) {
+                    # response types with no data structure (e.g. text/plain) should not be added
+                    $responses[$this->getTransferNameFromSchemaOrReference($response->schema)] = $responseProperties;
+                }
             }
         }
 

--- a/src/SprykerSdk/SyncApi/OpenApi/Builder/OpenApiCodeBuilder.php
+++ b/src/SprykerSdk/SyncApi/OpenApi/Builder/OpenApiCodeBuilder.php
@@ -8,6 +8,7 @@
 namespace SprykerSdk\SyncApi\OpenApi\Builder;
 
 use cebe\openapi\Reader;
+use cebe\openapi\spec\MediaType;
 use cebe\openapi\spec\OpenApi;
 use cebe\openapi\spec\Operation;
 use cebe\openapi\spec\PathItem;
@@ -563,16 +564,30 @@ class OpenApiCodeBuilder implements OpenApiCodeBuilderInterface
     protected function getPropertiesFromOperationContent(array $contents, array $responses): array
     {
         foreach ($contents as $response) {
-            if (isset($response->schema)) {
-                $responseProperties = $this->getResponsePropertiesFromSchemaOrReference($response->schema, []);
-                if ($responseProperties) {
-                    # response types with no data structure (e.g. text/plain) should not be added
-                    $responses[$this->getTransferNameFromSchemaOrReference($response->schema)] = $responseProperties;
-                }
+            $responseProperties = $this->getResponseProperties($response);
+            if ($responseProperties) {
+                $responses[$this->getTransferNameFromSchemaOrReference($response->schema)] = $responseProperties;
             }
         }
 
         return $responses;
+    }
+
+    /**
+     * @param \cebe\openapi\spec\MediaType $response
+     *
+     * @return array|null
+     */
+    protected function getResponseProperties(MediaType $response): ?array
+    {
+        if (isset($response->schema)) {
+            $responseProperties = $this->getResponsePropertiesFromSchemaOrReference($response->schema, []);
+            if ($responseProperties) {
+                return $responseProperties;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/SprykerSdk/SyncApi/OpenApi/Builder/OpenApiCodeBuilder.php
+++ b/src/SprykerSdk/SyncApi/OpenApi/Builder/OpenApiCodeBuilder.php
@@ -565,7 +565,7 @@ class OpenApiCodeBuilder implements OpenApiCodeBuilderInterface
         foreach ($contents as $response) {
             if (isset($response->schema)) {
                 $responseProperties = $this->getResponsePropertiesFromSchemaOrReference($response->schema, []);
-                if (!empty($responseProperties)) {
+                if ($responseProperties) {
                     # response types with no data structure (e.g. text/plain) should not be added
                     $responses[$this->getTransferNameFromSchemaOrReference($response->schema)] = $responseProperties;
                 }

--- a/tests/_data/api/valid/valid_openapi.yml
+++ b/tests/_data/api/valid/valid_openapi.yml
@@ -36,6 +36,13 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/ApiErrorMessage'
+                500:
+                    description: 'Server error'
+                    content:
+                        # servers may want to report the error directly as simple text if things go very wrong
+                        text/plain:
+                            schema:
+                                type: string
                 default:
                     description: 'Expected response to a bad request.'
                     content:


### PR DESCRIPTION
- Developer(s): @k4emic, @bohdan-turchyk-spryker

- Ticket: https://spryker.atlassian.net/browse/APPS-4625

- Docs PR: ACADEMY_URL_HERE

- Release Group: URL_HERE

- merge: merge

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   SyncApi               | patch (currently 0.x)  |                       |

-----------------------------------------

#### Module SyncApi

##### Change log

Improvements

- Extended logic to skip code generation for response schemas without data structures (e.g. `text/plain` response type - using it would result in bad parameters being passed to `spryk` resulting in exceptions).